### PR TITLE
fix: overlapping red boxes

### DIFF
--- a/model_inference/inference.py
+++ b/model_inference/inference.py
@@ -37,20 +37,27 @@ async def process_inference_results(data, imageDims):
                         and box["box"]["topX"] <= box2["box"]["bottomX"]
                         and box["box"]["topY"] <= box2["box"]["bottomY"]
                     ):
-                        if box["score"] >= box2["score"]:
+                        # box2 is the lower score box
+                        if box2["score"] < box["score"]:
                             data[0]["boxes"][j]["overlapping"] = True
                             data[0]["boxes"][i]["overlappingIndices"].append(j + 1)
                             box2["box"]["bottomX"] = box["box"]["bottomX"]
                             box2["box"]["bottomY"] = box["box"]["bottomY"]
                             box2["box"]["topX"] = box["box"]["topX"]
                             box2["box"]["topY"] = box["box"]["topY"]
-                        else:
+                        # box is the lower score box
+                        elif box["score"] < box2["score"]:
                             data[0]["boxes"][i]["overlapping"] = True
                             data[0]["boxes"][i]["overlappingIndices"].append(j + 1)
                             box["box"]["bottomX"] = box2["box"]["bottomX"]
                             box["box"]["bottomY"] = box2["box"]["bottomY"]
                             box["box"]["topX"] = box2["box"]["topX"]
                             box["box"]["topY"] = box2["box"]["topY"]
+                        # Unsure whether or not they should be marked as overlapping.
+                        # else:
+                        #     data[0]["boxes"][i]["overlapping"] = True
+                        #     data[0]["boxes"][j]["overlapping"] = True
+
         labelOccurrence = {}
         for i, box in enumerate(data[0]["boxes"]):
             if box["label"] not in labelOccurrence:

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -1,0 +1,55 @@
+import unittest
+import model_inference.inference as inference
+
+import asyncio
+
+box1 = {
+    "topX": 1,
+    "topY": 1,
+    "bottomX": 40,
+    "bottomY": 40,
+}
+box2 = {
+    "topX": 20,
+    "topY": 20,
+    "bottomX":60,
+    "bottomY": 40,
+}
+
+class TestInferenceProcessFunction(unittest.TestCase):
+    def test_process_inference_overlap_results(self):
+        boxes = [
+            {"box": box1, "score": 20, "label": "box1"},
+            {"box": box2, "score": 10, "label": "box2"}
+        ]
+        data = {
+            "boxes": boxes,
+            "totalBoxes": 2
+        }
+        result = asyncio.run(inference.process_inference_results(data=[data], imageDims=[100, 100]))
+
+
+        self.assertFalse(result[0]["boxes"][0]["overlapping"])
+        self.assertTrue(result[0]["boxes"][1]["overlapping"])
+
+        print(result)
+        # self.assertEqual(result, None)
+    def test_process_inference_overlap_score_results(self):
+        boxes = [
+            {"box": box1, "score": 10, "label": "box1"},
+            {"box": box2, "score": 10, "label": "box2"}
+        ]
+        data = {
+            "boxes": boxes,
+            "totalBoxes": 2
+        }
+        result = asyncio.run(inference.process_inference_results(data=[data], imageDims=[100, 100]))
+
+
+        self.assertFalse(result[0]["boxes"][0]["overlapping"])
+        self.assertFalse(result[0]["boxes"][1]["overlapping"])
+
+        # self.assertEqual(result, None)
+        
+
+


### PR DESCRIPTION
The `process_inference_results` function has been fixed to ensure that red boxes are adjusted and marked as overlapped only when one has a score that is strictly superior to the other. Additionally, a test has been added to verify the functionality of the modified function.

https://github.com/ai-cfia/nachet-backend/issues/62