### PR TITLE
94 manage picture set in directories endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,11 +45,12 @@ backend->>+AzureStorageAPI: (async) upload_inference_result(json)
 
 ### RUNNING NACHET-BACKEND FROM DEVCONTAINER
 
-When developping you first need to install the packages required. 
+When developping you first need to install the packages required.
 
 This command must be run the **first time** you want to run the backend on your
-computer, but also **every time** you update the requirements.txt file and **every time** the
-datastore repo is updated
+computer, but also **every time** you update the requirements.txt file and
+**every time** the datastore repo is updated
+
 ```bash
 pip install -r requirements.txt
 ```

--- a/README.md
+++ b/README.md
@@ -45,8 +45,16 @@ backend->>+AzureStorageAPI: (async) upload_inference_result(json)
 
 ### RUNNING NACHET-BACKEND FROM DEVCONTAINER
 
-When you are developping, you can run the program while in the devcontainer by
-using this command:
+When developping you first need to install the packages required. 
+
+This command musy be run the **first time** you want to run the backend on your
+computer, but also **every time** you update the requirements.txt file and **every time** the
+datastore repo is updated
+```bash
+pip install -r requirements.txt
+```
+
+Then, you can run the backend while in the devcontainer by using this command:
 
 ```bash
 hypercorn -b :8080 app:app

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ backend->>+AzureStorageAPI: (async) upload_inference_result(json)
 
 When developping you first need to install the packages required. 
 
-This command musy be run the **first time** you want to run the backend on your
+This command must be run the **first time** you want to run the backend on your
 computer, but also **every time** you update the requirements.txt file and **every time** the
 datastore repo is updated
 ```bash

--- a/app.py
+++ b/app.py
@@ -197,6 +197,41 @@ async def get_user_id() :
         print(error)
         return jsonify([f"GetUserIdError: {str(error)}"]), 400
 
+# Deprecated
+@app.post("/del")
+async def delete_directory():
+    """
+    deletes a directory in the user's container
+    """
+    try:
+        data = await request.get_json()
+        container_name = data["container_name"]
+        folder_name = data["folder_name"]
+        if container_name and folder_name:
+            container_client = await azure_storage.mount_container(
+                CONNECTION_STRING, container_name, create_container=True
+            )
+            if container_client:
+                folder_uuid = await azure_storage.get_folder_uuid(
+                    container_client, folder_name
+                )
+                if folder_uuid:
+                    blob_list = container_client.list_blobs()
+                    for blob in blob_list:
+                        if blob.name.split("/")[0] == folder_uuid:
+                            container_client.delete_blob(blob.name)
+                    return jsonify([True]), 200
+                else:
+                    raise DeleteDirectoryRequestError("directory does not exist")
+            else:
+                raise DeleteDirectoryRequestError("failed to mount container")
+        else:
+            raise DeleteDirectoryRequestError("missing container or directory name")
+
+    except (KeyError, TypeError, azure_storage.MountContainerError, ResourceNotFoundError, DeleteDirectoryRequestError, ServiceResponseError) as error:
+        print(error)
+        return jsonify([f"DeleteDirectoryRequestError: {str(error)}"]), 400
+
 @app.post("/delete-request")
 async def delete_request():
     """

--- a/app.py
+++ b/app.py
@@ -235,10 +235,11 @@ async def delete_directory():
 @app.post("/delete-request")
 async def delete_request():
     """
-    deletes a directory in the user's container
+    Request to delete a directory in the user's container.
+    
+    Return true if there is validated pictuers in it, false otherwise
     """
     try:
-        print("yes")
         data = await request.get_json()
         user_id = data["container_name"]
         picture_set_id = data["folder_uuid"]
@@ -262,7 +263,7 @@ async def delete_request():
 @app.post("/delete-permanently")
 async def delete_permanently():
     """
-    deletes a directory in the user's container
+    deletes a directory in the user's container permanently
     """
     try:
         data = await request.get_json()
@@ -292,7 +293,7 @@ async def delete_permanently():
 @app.post("/delete-with-archive")
 async def delete_with_archive():
     """
-    deletes a directory in the user's container
+    deletes a directory in the user's container and saves the validated pictures in the dev user container
     """
     try:
         data = await request.get_json()

--- a/docs/nachet-feedback-documentation.md
+++ b/docs/nachet-feedback-documentation.md
@@ -1,4 +1,4 @@
-# Import Folder Images
+# User inference feedback
 
 ## Executive summary
 

--- a/docs/nachet-manage-folders.md
+++ b/docs/nachet-manage-folders.md
@@ -65,12 +65,11 @@ same applies to pictures imported in batches, which have been downloaded for
 training purposes. Our solution is to request confirmation from the user, who
 can decide to delete pictures from his container but let us save them, or he can
 delete everything anyway, for example if there has been a missed click.
- 
+
 ## Prerequisites
 
 - The user must be signed in and have an Azure Storage Container
 - The backend need to have a connection with the datastore
-
 
 ## Sequence Diagram
 
@@ -138,7 +137,6 @@ note left of FE : "Are you sure ? Everything in this folder will be deleted and 
     end
 
 ```
-
 
 ## API Routes
 

--- a/docs/nachet-manage-folders.md
+++ b/docs/nachet-manage-folders.md
@@ -1,0 +1,169 @@
+# Manage folders
+
+## Executive summary
+
+A user is able to have a preview of his blob storage container in the Nachet
+application. He can have many folders in his container and pictures in it. Since
+we have the database, those folders are related to the picture_set table and
+each pictures is also saved in the database. Here is the schema of actual
+database.
+
+``` mermaid
+---
+title: Extract from Nachet DB Structure 
+---
+erDiagram
+  picture_set{
+    uuid id PK
+    json picture_set
+    uuid owner_id FK
+    timestamp upload_date
+  }
+  picture{
+    uuid id PK
+    json picture
+    uuid picture_set_id FK
+    uuid parent FK
+    int nb_object
+    boolean verified
+    timestamp upload_date 
+  }
+inference{
+    uuid id PK
+    json inference 
+    uuid picture_id FK
+    uuid user_id FK
+    timestamp upload_date
+  }
+  picture_seed{
+    uuid id PK
+    uuid picture_id FK
+    uuid seed_id FK
+    timestamp upload_date
+  }
+  picture_set ||--o{picture: contains
+  picture ||--o{picture: cropped
+  picture |o--o{picture_seed: has
+  picture_seed }o--o| seed: has
+  inference ||--o{ object: detects
+  object ||--o{ seed_object: is
+  seed_object }o--|| seed: is
+  inference ||--|| picture: infers
+
+```
+
+From the nachet application, a user can create and delete folders, so the blob
+storage and the database must be correctly updated.
+
+When a folder is created, it takes on a name and is created as a picture_set in
+the database and as a folder in the blob storage container of the user.
+
+There are more issues when the user wants to delete a folder. If the folder
+contains validated pictures, it may be useful for training purpose, because it
+means there is a valid inference associate with each seed on the picture. The
+same applies to pictures imported in batches, which have been downloaded for
+training purposes. Our solution is to request confirmation from the user, who
+can decide to delete pictures from his container but let us save them, or he can
+delete everything anyway, for example if there has been a missed click.
+ 
+## Prerequisites
+
+- The user must be signed in and have an Azure Storage Container
+- The backend need to have a connection with the datastore
+
+
+## Sequence Diagram
+
+### Delete use case
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant FE
+    participant BE
+    participant DS
+
+    User->>FE: Delete Folder
+    rect rgb(200, 50, 50)
+      FE->>BE: /delete-request
+    end
+    rect rgb(200, 50, 50)
+          BE->>DS: Check if there are validated inferences or pictures from a batch import
+note left of DS: Check for picture_seed entities linked to picture id<br> since a verified inference and a batch upload has those
+    end
+    alt picture_seed exist
+        DS-->>BE: Validated inference status or pictures from batch import
+        BE->>FE: True : Request user confirmation
+        rect rgb(200, 50, 50)
+            FE->>User: Ask to keep data for training
+note left of FE : "Some of those pictures were validated or upload via the batch import.<br>Do you want us to keep them for training ? <br>If yes, your folder will be deleted but we'll keep the validated pictures.<br>If no, everything will be deleted and unrecoverable.
+        end
+        alt No
+            User ->>FE: delete all
+            rect rgb(200, 50, 50)
+                FE-->BE:  /delete-permanently
+            end
+            BE->>DS: delete picture_set
+        else YES
+            User ->>FE: Keep them
+            rect rgb(200, 50, 50)
+                FE-->BE: /delete-with-archive
+            end
+            rect rgb(200, 50, 50)
+                BE->>DS: archive data for validated inferences and batch import in picture_set
+                    note left of DS: "Pictures are moved in different container <br> DB entities updated" 
+                BE->>DS: delete picture_set
+                   note left of DS: "Folder and all the files left are deleted, <br>related pictures, inference are deleted." 
+            end
+       else CANCEL
+            User ->>FE: cancel : nothing happens
+       end
+    else no picture_seed exist
+        DS-->>BE: No pictures with validated inference status or from batch import
+        BE-->>FE: False: confirmation to delete the folder
+        rect rgb(200, 50, 50)
+            FE->>User: Ask confirmation
+note left of FE : "Are you sure ? Everything in this folder will be deleted and unrecoverable"
+        end
+        alt Yes
+            User ->>FE: delete all
+            rect rgb(200, 50, 50)
+                FE-->BE:  /delete-permanently
+            end
+            BE->>DS: delete picture_set
+        else CANCEL
+            User ->>FE: cancel : nothing happens
+        
+        end
+    end
+
+```
+
+
+## API Routes
+
+### /create-dir
+
+The `create-dir` route need a folder_name and create the folder in database and
+in Azure Blob storage.
+
+### /dir
+
+The `dir` route retreives all user directories from the database (id, name and
+nb_pictures).
+
+### /delete-request
+
+The `delete-request` route return True if there is validated pictures in the
+given folder or False else.
+
+### /delete-permanently
+
+THe `delete-permanently`route delete the given folder, it means it delete the
+picture_set and every things related in database, and it delete all blobs in the
+azure blob storage.
+
+### /delete-with-archive
+
+The `delete-with-archive` route delete the given folder from the user container
+but move everything in it n the dev container.

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,4 +10,4 @@ cryptography
 pyyaml
 pydantic
 python-magic
-nachet-datastore @git+https://github.com/ai-cfia/nachet-datastore.git@d7522c6609a028bf8300612e7bddb8de861da1dd
+nachet-datastore @git+https://github.com/ai-cfia/nachet-datastore.git@5bbe31e9d6b95b8c2650cda0233bb45468f8b1f0

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,4 +10,4 @@ cryptography
 pyyaml
 pydantic
 python-magic
-nachet-datastore @git+https://github.com/ai-cfia/nachet-datastore.git@53477bd33f0e36c8ec1e5649977e47910aa017dd
+nachet-datastore @git+https://github.com/ai-cfia/nachet-datastore.git@main

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,4 +10,4 @@ cryptography
 pyyaml
 pydantic
 python-magic
-nachet-datastore @git+https://github.com/ai-cfia/nachet-datastore.git@main
+nachet-datastore @git+https://github.com/ai-cfia/nachet-datastore.git@53477bd33f0e36c8ec1e5649977e47910aa017dd

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,4 +10,4 @@ cryptography
 pyyaml
 pydantic
 python-magic
-nachet-datastore @git+https://github.com/ai-cfia/nachet-datastore.git@5bbe31e9d6b95b8c2650cda0233bb45468f8b1f0
+nachet-datastore @git+https://github.com/ai-cfia/nachet-datastore.git@main

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,4 +10,4 @@ cryptography
 pyyaml
 pydantic
 python-magic
-nachet-datastore @git+https://github.com/ai-cfia/nachet-datastore.git@main
+nachet-datastore @git+https://github.com/ai-cfia/nachet-datastore.git@d7522c6609a028bf8300612e7bddb8de861da1dd

--- a/storage/datastore_storage_api.py
+++ b/storage/datastore_storage_api.py
@@ -128,7 +128,7 @@ async def save_annoted_feedback(cursor, feedback_dict):
 
 async def delete_directory_request(cursor, user_id, picture_set_id):
     try :
-        return len(await datastore.(cursor, user_id, picture_set_id)) > 0
+        return len(await datastore.find_validated_pictures(cursor, user_id, picture_set_id)) > 0
     except Exception as error:
         raise DatastoreError(error)
 

--- a/storage/datastore_storage_api.py
+++ b/storage/datastore_storage_api.py
@@ -128,7 +128,7 @@ async def save_annoted_feedback(cursor, feedback_dict):
 
 async def delete_directory_request(cursor, user_id, picture_set_id):
     try :
-        return len(await datastore.find_validated_pictures(cursor, user_id, picture_set_id)) > 0
+        return len(await datastore.(cursor, user_id, picture_set_id)) > 0
     except Exception as error:
         raise DatastoreError(error)
 

--- a/storage/datastore_storage_api.py
+++ b/storage/datastore_storage_api.py
@@ -30,7 +30,7 @@ def get_cursor(connection):
 def end_query(connection, cursor):
     db.end_query(connection, cursor)
  
-def get_all_seeds() -> list:
+async def get_all_seeds() -> list:
 
     """
     Return all seeds name register in the Datastore.
@@ -38,7 +38,7 @@ def get_all_seeds() -> list:
     try:
         connection = get_connection()
         cursor = get_cursor(connection)
-        return datastore.get_seed_info(cursor)
+        return await datastore.get_seed_info(cursor)
     except Exception as error: # TODO modify Exception for more specific exception
         raise SeedNotFoundError(error.args[0])
 
@@ -126,9 +126,21 @@ async def save_perfect_feedback(cursor, inference_id:str, user_id:str, boxes_id)
 async def save_annoted_feedback(cursor, feedback_dict):
     await datastore.new_correction_inference_feedback(cursor, feedback_dict)
 
-async def delete_directory(cursor, user_id, picture_set_id, container_client):
+async def delete_directory_request(cursor, user_id, picture_set_id):
     try :
-        await datastore.delete_picture_set(cursor, user_id, picture_set_id, container_client)
+        return len(await datastore.find_validated_pictures(cursor, user_id, picture_set_id)) > 0
+    except Exception as error:
+        raise DatastoreError(error)
+
+async def delete_directory_permanently(cursor, user_id, picture_set_id, container_client):
+    try :
+        return await datastore.delete_picture_set_permanently(cursor, user_id, picture_set_id, container_client)
+    except Exception as error:
+        raise DatastoreError(error)
+
+async def delete_directory_with_archive(cursor, user_id, picture_set_id, container_client):
+    try :
+        return await datastore.delete_picture_set_with_archive(cursor, user_id, picture_set_id, container_client)
     except Exception as error:
         raise DatastoreError(error)
     

--- a/storage/datastore_storage_api.py
+++ b/storage/datastore_storage_api.py
@@ -98,12 +98,12 @@ def upload_pictures(cursor, user_id, picture_set_id, container_client, pictures,
     except Exception as error:
         raise DatastoreError(error)
     
-async def create_picture_set(cursor, container_client, user_id: str, nb_pictures: int):
+async def create_picture_set(cursor, container_client, user_id: str, nb_pictures: int, folder_name = None):
     try :
-        return await datastore.create_picture_set(cursor, container_client, nb_pictures, user_id)
+        return await datastore.create_picture_set(cursor, container_client, nb_pictures, user_id, folder_name)
     except Exception as error:
         raise DatastoreError(error)
-    
+
 async def get_pipelines() -> list:
 
     """
@@ -125,3 +125,12 @@ async def save_perfect_feedback(cursor, inference_id:str, user_id:str, boxes_id)
     
 async def save_annoted_feedback(cursor, feedback_dict):
     await datastore.new_correction_inference_feedback(cursor, feedback_dict)
+
+async def delete_directory(cursor, picture_set_id):
+    await datastore.delete_picture_set(cursor, picture_set_id)
+    
+async def get_directories(cursor, user_id):
+    try :
+        return await datastore.get_picture_sets_info(cursor, user_id)
+    except Exception as error:
+        raise DatastoreError(error)

--- a/storage/datastore_storage_api.py
+++ b/storage/datastore_storage_api.py
@@ -126,8 +126,11 @@ async def save_perfect_feedback(cursor, inference_id:str, user_id:str, boxes_id)
 async def save_annoted_feedback(cursor, feedback_dict):
     await datastore.new_correction_inference_feedback(cursor, feedback_dict)
 
-async def delete_directory(cursor, picture_set_id):
-    await datastore.delete_picture_set(cursor, picture_set_id)
+async def delete_directory(cursor, user_id, picture_set_id, container_client):
+    try :
+        await datastore.delete_picture_set(cursor, user_id, picture_set_id, container_client)
+    except Exception as error:
+        raise DatastoreError(error)
     
 async def get_directories(cursor, user_id):
     try :


### PR DESCRIPTION
ref epic #94 

The delete endpoints are ready to be merged. I keep the old `/del` route to avoid errors in the frontend since it doesn't use the new routes yet.
It also included updates for `/dir` and `/create-dir` routes